### PR TITLE
change python to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Ein kleines Programm um das Fahrgastrechte-Formular der DB einfacher auszufülle
 Benötigt werden `npyscreen` und `fdfgen`, zB via
 
 ```
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 Danach einfach
 
 ```
-python fahrgastrechte.py
+python3 fahrgastrechte.py
 ```
 
 Dort das Formular ausfüllen (nicht benötigte Felder leer lassen) und dann auf der letzten Seite "Generate Form" betätigen.


### PR DESCRIPTION
changed python (resp. pip) command to python3, because according to PEP 394, python should refer to python2

https://www.python.org/dev/peps/pep-0394/